### PR TITLE
Update textext.py (pdf2svg availability check)

### DIFF
--- a/textextLib/textext.py
+++ b/textextLib/textext.py
@@ -701,7 +701,7 @@ class Pdf2Svg(PdfConverterBase):
 
     def available(cls):
         """Check whether pdf2svg is available, raise RuntimeError if not"""
-        exec_command(['pdf2svg'], ok_return_value=254)
+        exec_command(['pdf2svg'], ok_return_value=None)
     available = classmethod(available)
 
 #original: CONVERTERS = [Pdf2Svg, PstoeditPlotSvg, SkConvert]


### PR DESCRIPTION
`pdf2svg` returns `-2` (int) and not `254` (uint) when available.
When the file is not available, it is handled by the `try-catch` block in `exec_command()` anyways.