### PR TITLE
Updated minimal LaTeX example

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -119,7 +119,7 @@ You should be able to compile the following example on your system. Compiling th
        \documentclass[11pt]{article}
        \usepackage[utf8]{inputenc}
        \usepackage{amsmath,amsthm,amsbsy,amsfonts,amssymb}
-       \usepackage[per=slash]{siunitx}
+       \usepackage[per-mode=symbol]{siunitx}
        \usepackage{steinmetz}
        \begin{document}
        Minimal example. Woo-hoo!


### PR DESCRIPTION
Updated minimal LaTeX example for for version 2 of siunitx

See also https://github.com/fsmMLK/inkscapeCircuitSymbols/issues/28